### PR TITLE
CI fix: Supabase login/link for functions deploy

### DIFF
--- a/.github/workflows/supabase-functions.yml
+++ b/.github/workflows/supabase-functions.yml
@@ -28,9 +28,12 @@ jobs:
         with:
           version: latest
 
+      - name: Supabase login
+        run: |
+          supabase login --token "$SUPABASE_ACCESS_TOKEN"
       - name: Link project
         run: |
-          supabase link --project-ref "$SUPABASE_PROJECT_REF" --access-token "$SUPABASE_ACCESS_TOKEN"
+          supabase link --project-ref "$SUPABASE_PROJECT_REF"
 
       - name: Set Supabase secrets (conditional)
         run: |


### PR DESCRIPTION
Fix supabase link by adding 'supabase login --token' and removing deprecated '--access-token'. Re-run the Supabase Functions Deploy workflow after merge.