### PR TITLE
Fix: Supabase Functions deploy (syntax + secrets mapping)

### DIFF
--- a/.github/workflows/supabase-functions.yml
+++ b/.github/workflows/supabase-functions.yml
@@ -40,7 +40,7 @@ jobs:
           if [ -n "${{ secrets.STRIPE_SECRET_KEY }}" ]; then
             supabase secrets set --project-ref "$SUPABASE_PROJECT_REF" STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }}
           fi
-          supabase secrets set --project-ref "$SUPABASE_PROJECT_REF" SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }} APP_BASE_URL=${{ secrets.APP_BASE_URL }}
+          supabase secrets set --project-ref "$SUPABASE_PROJECT_REF" SERVICE_ROLE_KEY=${{ secrets.SUPABASE_SERVICE_ROLE_KEY }} APP_BASE_URL=${{ secrets.APP_BASE_URL }}
 
       - name: Deploy Edge Functions
         run: |

--- a/supabase/functions/admin_broadcast/index.ts
+++ b/supabase/functions/admin_broadcast/index.ts
@@ -14,11 +14,6 @@ type Filters = {
   relationship_status?: 'single'|'in_partnership'
 }
 
-deno: {
-  permissions: {
-    env: true,
-  }
-}
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders })

--- a/supabase/functions/seed/index.ts
+++ b/supabase/functions/seed/index.ts
@@ -10,8 +10,8 @@ Deno.serve(async (req) => {
   try {
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!
     const anon = Deno.env.get('SUPABASE_ANON_KEY')!
-    const service = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
-    if (!service) return new Response(JSON.stringify({ error: 'Missing service role key' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+    const service = Deno.env.get('SERVICE_ROLE_KEY')
+    if (!service) return new Response(JSON.stringify({ error: 'Missing SERVICE_ROLE_KEY' }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
 
     const authed = createClient(supabaseUrl, anon, { global: { headers: { Authorization: req.headers.get('Authorization') || '' } } })
     const { data: { user } } = await authed.auth.getUser()


### PR DESCRIPTION
Fix failing functions deploy: \n- Remove invalid 'deno' block in supabase/functions/admin_broadcast/index.ts (parse error).\n- Seed function reads SERVICE_ROLE_KEY (non-reserved name) instead of SUPABASE_SERVICE_ROLE_KEY.\n- Workflow maps repo secret SUPABASE_SERVICE_ROLE_KEY -> Supabase secret SERVICE_ROLE_KEY.\n\nAfter merge, re-run 'Supabase Functions Deploy'.