### PR TITLE
CI: Supabase db push (no DB_URL required)

### DIFF
--- a/.github/workflows/supabase-db-push.yml
+++ b/.github/workflows/supabase-db-push.yml
@@ -1,0 +1,31 @@
+name: Supabase DB Push (no DB_URL)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Supabase login
+        run: supabase login --token "$SUPABASE_ACCESS_TOKEN"
+
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Push migrations to remote
+        run: supabase db push --linked
+
+      - name: Summary
+        run: echo "Migrations pushed to $SUPABASE_PROJECT_REF"


### PR DESCRIPTION
Adds workflow to push SQL migrations using Supabase CLI after login/link. Avoids DB_URL escaping issues. Run via Actions → Supabase DB Push (no DB_URL needed).