### PR TITLE
Fix: missing inspirations table + non-interactive db push + seed feedback

### DIFF
--- a/.github/workflows/supabase-db-push.yml
+++ b/.github/workflows/supabase-db-push.yml
@@ -25,7 +25,7 @@ jobs:
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
 
       - name: Push migrations to remote
-        run: supabase db push --linked
+        run: supabase db push --linked --yes
 
       - name: Summary
         run: echo "Migrations pushed to $SUPABASE_PROJECT_REF"

--- a/src/pages/admin/AdminSettings.tsx
+++ b/src/pages/admin/AdminSettings.tsx
@@ -1,13 +1,19 @@
 import { Button } from '@/components/ui/button'
 import { supabase } from '@/integrations/supabase/client'
 import { useState } from 'react'
+import { toast } from '@/hooks/use-toast'
 
 export default function AdminSettings() {
   const [loading, setLoading] = useState(false)
   const seed = async () => {
     setLoading(true)
-    await supabase.functions.invoke('seed')
+    const { data, error } = await supabase.functions.invoke('seed')
     setLoading(false)
+    if (error) {
+      toast({ title: 'Seed fehlgeschlagen', description: error.message, variant: 'destructive' })
+    } else {
+      toast({ title: 'Seed erfolgreich', description: JSON.stringify(data) })
+    }
   }
   return (
     <div className="space-y-3">

--- a/supabase/migrations/20250823150000_create_datingideen_inspirations.sql
+++ b/supabase/migrations/20250823150000_create_datingideen_inspirations.sql
@@ -1,0 +1,41 @@
+-- Create inspirations table (required for later ALTERs)
+CREATE TABLE IF NOT EXISTS public.datingideen_inspirations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  location TEXT NOT NULL,
+  url TEXT,
+  category TEXT,
+  difficulty_level TEXT,
+  estimated_cost TEXT,
+  duration TEXT,
+  season TEXT,
+  general_location_info TEXT,
+  is_active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.datingideen_inspirations ENABLE ROW LEVEL SECURITY;
+
+-- Allow read to all authenticated users by default (adjust if needed)
+DO $$ BEGIN
+  CREATE POLICY datingideen_inspirations_read ON public.datingideen_inspirations
+  FOR SELECT USING (auth.role() = 'authenticated');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Update timestamp trigger function (reuse if exists)
+DO $$ BEGIN
+  CREATE OR REPLACE FUNCTION public.datingideen_update_updated_at_column()
+  RETURNS TRIGGER AS $$
+  BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+  END;$$ LANGUAGE plpgsql;
+END $$;
+
+-- Attach trigger
+DROP TRIGGER IF EXISTS datingideen_inspirations_updated_at ON public.datingideen_inspirations;
+CREATE TRIGGER datingideen_inspirations_updated_at
+  BEFORE UPDATE ON public.datingideen_inspirations
+  FOR EACH ROW EXECUTE FUNCTION public.datingideen_update_updated_at_column();


### PR DESCRIPTION
This PR fixes the migration failure and seed invisibility:\n- Add migration 20250823150000_create_datingideen_inspirations.sql so later ALTERs succeed.\n- Make Supabase DB Push non-interactive (--yes) to avoid prompt stalls.\n- Admin Settings: show toast for seed success/error so failures are visible.\nAfter merge: run 'Supabase DB Push (no DB_URL)' again, then run 'Supabase Functions Deploy', then click 'Demo‑Daten erstellen'.