### PR TITLE
CI(db): db push without link; set correct project_id

### DIFF
--- a/.github/workflows/supabase-db-push.yml
+++ b/.github/workflows/supabase-db-push.yml
@@ -21,11 +21,8 @@ jobs:
       - name: Supabase login
         run: supabase login --token "$SUPABASE_ACCESS_TOKEN"
 
-      - name: Link project
-        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
-
       - name: Push migrations to remote
-        run: supabase db push --linked --yes
+        run: supabase db push --project-ref "$SUPABASE_PROJECT_REF" --yes --debug
 
       - name: Summary
         run: echo "Migrations pushed to $SUPABASE_PROJECT_REF"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,4 +1,4 @@
-project_id = "owhgsndeztyqirihpjtw"
+project_id = "qkqveeduleuucumzvyyh"
 
 [functions.geocode]
 verify_jwt = false


### PR DESCRIPTION
Fix DB Push workflow failures by removing 'supabase link' (which errored with unexpected HTML) and running 'supabase db push --project-ref --yes --debug'. Also set supabase/config.toml project_id to qkqveeduleuucumzvyyh to match your project. After merge, run 'Supabase DB Push (no DB_URL)'.