### PR TITLE
Fix(client): switch to Vercel env for Supabase (VITE_SUPABASE_URL/ANON_KEY)

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://owhgsndeztyqirihpjtw.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im93aGdzbmRlenR5cWlyaWhwanR3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU3ODcyNTgsImV4cCI6MjA3MTM2MzI1OH0.1vh37LMk7bYwB-atNJ1Ja2VHg4_8MVt17jfKSqG5JoU";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
The app was still pointing to the old Supabase project via hardcoded URL/key. This PR switches to Vercel env vars:\n- VITE_SUPABASE_URL = https://qkqveeduleuucumzvyyh.supabase.co\n- VITE_SUPABASE_ANON_KEY = (from Supabase → Project Settings → API → anon key)\nAfter merge, set these in Vercel Project Settings → Environment Variables and redeploy. Then seed will hit the correct project and work.